### PR TITLE
Insert icons at selected node

### DIFF
--- a/src/code.ts
+++ b/src/code.ts
@@ -104,6 +104,7 @@ function dropIcon(payload: DropPayload) {
   node.constrainProportions = true;
   node.x = bounds.x + xFromCanvas / zoom - offset.x;
   node.y = bounds.y + yFromCanvas / zoom - offset.y;
+  node.setPluginData(CUSTOM_NODE_KEY, "true");
 
   node.children.forEach((child) => ungroup(child, node));
 

--- a/src/code.ts
+++ b/src/code.ts
@@ -27,9 +27,37 @@ figma.ui.onmessage = ({ type, payload }) => {
   }
 };
 
+/**
+ * Get the first selected node *or* the current page if the first node does not
+ * support children.
+ */
+function getSelectedNode() {
+  const [selectedNode] = figma.currentPage.selection;
+
+  if (!selectedNode) {
+    return figma.currentPage;
+  }
+
+  if (
+    selectedNode.type === "COMPONENT" ||
+    selectedNode.type === "FRAME" ||
+    selectedNode.type === "GROUP"
+  ) {
+    return selectedNode;
+  }
+
+  if (selectedNode.parent) {
+    return selectedNode.parent;
+  }
+
+  return figma.currentPage;
+}
+
 function insertIcon(payload: { name: string; svg: string }) {
   const tempNode = figma.createNodeFromSvg(payload.svg);
-  const node = figma.group(tempNode.children, figma.currentPage);
+  const selectedNode = getSelectedNode();
+
+  const node = figma.group(tempNode.children, selectedNode);
   tempNode.remove();
 
   const { x, y } = figma.viewport.center;


### PR DESCRIPTION
Hey! 

I've been loving using the Phosphor plugin but found it frustrating to keep dragging the inserted icons into the currently selected node.

This PR tweaks the existing behaviour to:

- Insert and offset the icon into the selected node if the selected node is a `COMPONENT`, `FRAME` or `GROUP` type
- Add a custom prop to each inserted icon to prevent inserted icons being nested within each other
- Inserted icon is centered on top of selected node if it does not support children and has a width property (e.g. a rectangle)
- Stacks icons horizontally when currently selected node is a Phosphor icon
- Removes the automatic moving of the viewport when an icon is inserted (it was a little jarring IMO)

The video below shows how it behaves in a container with no auto layout, another container with auto layout and finally if there is nothing currently selected.

https://user-images.githubusercontent.com/4908432/149162662-20fcd32e-6653-41db-be4f-9ba57c4069d8.mp4

The `if` blocks to determine what you can and can't do feel a bit meh but I couldn't see a nicer way to do it in the Figma API docs.

Hopefully this is useful 🙏 